### PR TITLE
[Feat] 통계 일자별 API 서비스 로직 구현

### DIFF
--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/repository/HashTagRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/repository/HashTagRepository.java
@@ -2,6 +2,17 @@ package com.allclear.socialhub.post.common.hashtag.repository;
 
 import com.allclear.socialhub.post.common.hashtag.domain.HashTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+
+    @Query("SELECT ph.post.id " +
+            "FROM HashTag AS h " +
+            "INNER JOIN PostHashTag AS ph on h.id = ph.hashTag.id " +
+            "where h.content = :hashtag")
+    List<Long> getPostByHashtag(@Param("hashtag") String hashtag);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
@@ -1,7 +1,25 @@
 package com.allclear.socialhub.post.common.like.repository;
 
 import com.allclear.socialhub.post.common.like.domain.PostLike;
+import com.allclear.socialhub.post.common.response.StatisticResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    @Query("SELECT DATE_FORMAT(pl.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+            "FROM PostLike AS pl " +
+            "WHERE pl.post.id in :postIds " +
+            "AND DATE(pl.createdAt) BETWEEN :start AND :end " +
+            "GROUP BY DATE_FORMAT(pl.createdAt, '%Y-%m-%d') " +
+            "ORDER BY time ASC")
+    List<StatisticResponse> findStatisticDtoByPostIds(
+            @Param("postIds") List<Long> postIds,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
@@ -17,7 +17,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
             "AND DATE(pl.createdAt) BETWEEN :start AND :end " +
             "GROUP BY DATE_FORMAT(pl.createdAt, '%Y-%m-%d') " +
             "ORDER BY time ASC")
-    List<StatisticResponse> findStatisticDtoByPostIds(
+    List<StatisticResponse> findDailyStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
             @Param("end") LocalDate end);

--- a/src/main/java/com/allclear/socialhub/post/common/response/StatisticResponse.java
+++ b/src/main/java/com/allclear/socialhub/post/common/response/StatisticResponse.java
@@ -1,0 +1,9 @@
+package com.allclear.socialhub.post.common.response;
+
+public interface StatisticResponse {
+
+    String getTime();
+
+    double getValue();
+
+}

--- a/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
@@ -17,7 +17,7 @@ public interface PostShareRepository extends JpaRepository<PostShare, Long> {
             "AND DATE(ps.createdAt) BETWEEN :start AND :end " +
             "GROUP BY DATE_FORMAT(ps.createdAt, '%Y-%m-%d') " +
             "ORDER BY time ASC")
-    List<StatisticResponse> findStatisticDtoByPostIds(
+    List<StatisticResponse> findDailyStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
             @Param("end") LocalDate end);

--- a/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
@@ -1,7 +1,25 @@
 package com.allclear.socialhub.post.common.share.repository;
 
+import com.allclear.socialhub.post.common.response.StatisticResponse;
 import com.allclear.socialhub.post.common.share.domain.PostShare;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface PostShareRepository extends JpaRepository<PostShare, Long> {
+
+    @Query("SELECT DATE_FORMAT(ps.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+            "FROM PostShare AS ps " +
+            "WHERE ps.post.id in :postIds " +
+            "AND DATE(ps.createdAt) BETWEEN :start AND :end " +
+            "GROUP BY DATE_FORMAT(ps.createdAt, '%Y-%m-%d') " +
+            "ORDER BY time ASC")
+    List<StatisticResponse> findStatisticDtoByPostIds(
+            @Param("postIds") List<Long> postIds,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
@@ -1,7 +1,25 @@
 package com.allclear.socialhub.post.common.view.repository;
 
+import com.allclear.socialhub.post.common.response.StatisticResponse;
 import com.allclear.socialhub.post.common.view.domain.PostView;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface PostViewRepository extends JpaRepository<PostView, Long> {
+
+    @Query("SELECT DATE_FORMAT(pv.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+            "FROM PostView AS pv " +
+            "WHERE pv.post.id in :postIds " +
+            "AND DATE(pv.createdAt) BETWEEN :start AND :end " +
+            "GROUP BY DATE_FORMAT(pv.createdAt, '%Y-%m-%d') " +
+            "ORDER BY time ASC")
+    List<StatisticResponse> findStatisticDtoByPostIds(
+            @Param("postIds") List<Long> postIds,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
@@ -17,7 +17,7 @@ public interface PostViewRepository extends JpaRepository<PostView, Long> {
             "AND DATE(pv.createdAt) BETWEEN :start AND :end " +
             "GROUP BY DATE_FORMAT(pv.createdAt, '%Y-%m-%d') " +
             "ORDER BY time ASC")
-    List<StatisticResponse> findStatisticDtoByPostIds(
+    List<StatisticResponse> findDailyStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
             @Param("end") LocalDate end);

--- a/src/main/java/com/allclear/socialhub/post/dto/StatisticDto.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/StatisticDto.java
@@ -1,0 +1,13 @@
+package com.allclear.socialhub.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class StatisticDto {
+
+    private String time;
+    private double value;
+
+}

--- a/src/main/java/com/allclear/socialhub/post/repository/PostRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/PostRepository.java
@@ -1,7 +1,25 @@
 package com.allclear.socialhub.post.repository;
 
+import com.allclear.socialhub.post.common.response.StatisticResponse;
 import com.allclear.socialhub.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("SELECT DATE_FORMAT(p.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+            "FROM Post AS p " +
+            "WHERE p.id in :postIds " +
+            "AND DATE(p.createdAt) BETWEEN :start AND :end " +
+            "GROUP BY DATE_FORMAT(p.createdAt, '%Y-%m-%d') " +
+            "ORDER BY time ASC")
+    List<StatisticResponse> findDailyStatisticByPostIds(
+            @Param("postIds") List<Long> postIds,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/service/StatisticService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/StatisticService.java
@@ -2,14 +2,16 @@ package com.allclear.socialhub.post.service;
 
 import com.allclear.socialhub.post.domain.StatisticType;
 import com.allclear.socialhub.post.domain.StatisticValue;
+import com.allclear.socialhub.post.dto.StatisticDto;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 public interface StatisticService {
 
-    void getStatisticsDaily(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value);
+    List<StatisticDto> getStatisticsDaily(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value);
 
     void getStatisticsHourly(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value);
 

--- a/src/main/java/com/allclear/socialhub/post/service/StatisticServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/StatisticServiceImpl.java
@@ -1,18 +1,87 @@
 package com.allclear.socialhub.post.service;
 
+import com.allclear.socialhub.post.common.hashtag.repository.HashTagRepository;
+import com.allclear.socialhub.post.common.like.repository.PostLikeRepository;
+import com.allclear.socialhub.post.common.response.StatisticResponse;
+import com.allclear.socialhub.post.common.share.repository.PostShareRepository;
+import com.allclear.socialhub.post.common.view.repository.PostViewRepository;
 import com.allclear.socialhub.post.domain.StatisticType;
 import com.allclear.socialhub.post.domain.StatisticValue;
+import com.allclear.socialhub.post.dto.StatisticDto;
+import com.allclear.socialhub.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class StatisticServiceImpl implements StatisticService {
 
+    private final HashTagRepository hashTagRepository;
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostShareRepository postShareRepository;
+    private final PostViewRepository postViewRepository;
 
+    /**
+     * 1. 일자별 통계
+     * 작성자 : 김효진
+     *
+     * @param hashtag
+     * @param type    : 일자별, 시간별
+     * @param start   : start date
+     * @param end     : end date
+     * @param value   : count, like_count, share_count, view_count
+     * @return List<StatisticDto>
+     */
     @Override
-    public void getStatisticsDaily(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value) {
-        
+    public List<StatisticDto> getStatisticsDaily(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value) {
+
+        List<Long> postIds = hashTagRepository.getPostByHashtag(hashtag);
+        List<StatisticResponse> responses = new ArrayList<>();
+        if (value.equals(StatisticValue.COUNT)) {
+            responses = postRepository.findDailyStatisticByPostIds(postIds, start, end);
+        } else if (value.equals(StatisticValue.LIKE_COUNT)) {
+            responses = postLikeRepository.findDailyStatisticByPostIds(postIds, start, end);
+        } else if (value.equals(StatisticValue.SHARE_COUNT)) {
+            responses = postShareRepository.findDailyStatisticByPostIds(postIds, start, end);
+        } else if (value.equals(StatisticValue.VIEW_COUNT)) {
+            responses = postViewRepository.findDailyStatisticByPostIds(postIds, start, end);
+        }
+
+        List<StatisticDto> daily = getDaily(start, end);
+        for (StatisticDto statisticDto : daily) {
+            String time = statisticDto.getTime();
+            List<StatisticResponse> filteredList = responses.stream().filter(it -> it.getTime().equals(time)).collect(Collectors.toList());
+            if (filteredList.size() > 0) {
+                statisticDto.setValue(filteredList.get(0).getValue());
+            }
+        }
+
+        return daily;
+
+    }
+
+    private List<StatisticDto> getDaily(LocalDate start, LocalDate end) {
+
+        List<StatisticDto> result = new ArrayList<>();
+
+        List<LocalDate> localDates = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            // LocalDate를 문자열로 변환합니다.
+            String formattedDate = date.format(formatter);
+            StatisticDto statisticDto = new StatisticDto(formattedDate, 0L);
+            result.add(statisticDto);
+        }
+
+        return result;
+
     }
 
     @Override


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- daily statistics 기능 구현

## 🌱 반영 브랜치

- (반영 브랜치를 표시합니다. ex. `feat/login -> dev` ) 
- (이슈를 완료했다면 닫을 이슈의 번호를 표기합니다. ex. `close #1` )
- feat/#all-21-statistics-daliy -> feat/#all-21-statistics
- close #19 

<br/>

## 🔥 트러블 슈팅 (선택)

<br/>

<br/>
