### PR TITLE
[Feat] 게시물 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -1,9 +1,26 @@
 package com.allclear.socialhub.post.controller;
 
+import com.allclear.socialhub.post.dto.PostPaging;
+import com.allclear.socialhub.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/posts")
 public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping
+    public PostPaging getPosts(@PageableDefault Pageable pageable) {
+
+        return postService.getPosts(pageable);
+
+    }
+
 }

--- a/src/main/java/com/allclear/socialhub/post/dto/PostDto.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostDto.java
@@ -1,4 +1,0 @@
-package com.allclear.socialhub.post.dto;
-
-public class PostDto {
-}

--- a/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
@@ -1,0 +1,29 @@
+package com.allclear.socialhub.post.dto;
+
+import com.allclear.socialhub.post.domain.PostType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostListResponse {
+
+    private Long postId;
+    private List<String> hashtagList;
+    private PostType type;
+    private String title;
+    private String content;
+    private int viewCnt;
+    private int likeCnt;
+    private int shareCnt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
@@ -1,6 +1,7 @@
 package com.allclear.socialhub.post.dto;
 
 import com.allclear.socialhub.post.domain.PostType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +24,11 @@ public class PostListResponse {
     private int viewCnt;
     private int likeCnt;
     private int shareCnt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+    
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/allclear/socialhub/post/dto/PostPaging.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostPaging.java
@@ -1,0 +1,29 @@
+package com.allclear.socialhub.post.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostPaging {
+
+    private int postCnt;
+    private List<?> postList = new ArrayList<>();
+    private int pageSize;
+    private int page;
+    private int totalPage;
+
+    public PostPaging(Page<?> pageList) {
+
+        this.postCnt = (int) pageList.getTotalElements();
+        this.postList = pageList.getContent();
+        this.pageSize = pageList.getSize();
+        this.page = pageList.getPageable().getPageNumber();
+        this.totalPage = pageList.getTotalPages();
+    }
+
+}

--- a/src/main/java/com/allclear/socialhub/post/repository/PostRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/PostRepository.java
@@ -1,7 +1,9 @@
 package com.allclear.socialhub.post.repository;
 
 import com.allclear.socialhub.post.domain.Post;
+import com.allclear.socialhub.post.repository.querydsl.PostRepositoryQuerydsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl {
+
 }

--- a/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.allclear.socialhub.post.repository.querydsl;
+
+import com.allclear.socialhub.post.common.hashtag.domain.QHashTag;
+import com.allclear.socialhub.post.common.hashtag.domain.QPostHashTag;
+import com.allclear.socialhub.post.domain.QPost;
+import com.allclear.socialhub.post.dto.PostListResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PostRepositoryImpl implements PostRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PostRepositoryImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public Page<PostListResponse> getPosts(Pageable pageable) {
+
+        QPost post = QPost.post;
+        QHashTag hashtag = QHashTag.hashTag;
+        QPostHashTag postHashtag = QPostHashTag.postHashTag;
+
+        List<PostListResponse> postList = queryFactory
+                .select(
+                        Projections.bean(
+                                PostListResponse.class,
+                                post.id.as("postId"),
+                                post.type,
+                                post.title,
+                                post.content,
+                                post.viewCnt,
+                                post.likeCnt,
+                                post.shareCnt,
+                                post.createdAt,
+                                post.updatedAt
+                        )
+                )
+                .from(post)
+                .leftJoin(postHashtag).on(postHashtag.post.id.eq(post.id))
+                .leftJoin(hashtag).on(hashtag.id.eq(postHashtag.hashTag.id))
+                .groupBy(post.id)
+                .orderBy(post.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream()
+                .map(postListResponse -> {
+                    List<String> hashtagList = queryFactory
+                            .select(hashtag.content)
+                            .from(postHashtag)
+                            .join(hashtag).on(hashtag.id.eq(postHashtag.hashTag.id))
+                            .where(postHashtag.post.id.eq(postListResponse.getPostId()))
+                            .fetch();
+                    postListResponse.setHashtagList(hashtagList);
+
+                    return postListResponse;
+                })
+                .collect(Collectors.toList());
+
+        long total = queryFactory
+                .selectFrom(post)
+                .fetchCount();
+
+        return new PageImpl<>(postList, pageable, total);
+    }
+
+}

--- a/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryQuerydsl.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryQuerydsl.java
@@ -1,0 +1,11 @@
+package com.allclear.socialhub.post.repository.querydsl;
+
+import com.allclear.socialhub.post.dto.PostListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryQuerydsl {
+
+    Page<PostListResponse> getPosts(Pageable pageable);
+
+}

--- a/src/main/java/com/allclear/socialhub/post/service/PostService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostService.java
@@ -1,7 +1,10 @@
 package com.allclear.socialhub.post.service;
 
-import org.springframework.stereotype.Service;
+import com.allclear.socialhub.post.dto.PostPaging;
+import org.springframework.data.domain.Pageable;
 
-@Service
 public interface PostService {
+
+    PostPaging getPosts(Pageable pageable);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -1,0 +1,28 @@
+package com.allclear.socialhub.post.service;
+
+import com.allclear.socialhub.post.dto.PostPaging;
+import com.allclear.socialhub.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PostServiceImpl implements PostService {
+
+    private final PostRepository postRepository;
+
+    /**
+     * 1. 게시물 목록 조회
+     * 작성자 : 유리빛나
+     *
+     * @param pageable Pagination 요청 정보 관련 인터페이스
+     * @return 페이징 처리가 된 게시물 전체 목록
+     */
+    public PostPaging getPosts(Pageable pageable) {
+
+        return new PostPaging(postRepository.getPosts(pageable));
+    }
+
+
+}

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -13,7 +13,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
 
     /**
-     * 1. 게시물 목록 조회
+     * 5. 게시물 목록 조회
      * 작성자 : 유리빛나
      *
      * @param pageable Pagination 요청 정보 관련 인터페이스


### PR DESCRIPTION
## 📌 작업 내용
- 게시물 목록 응답, 페이지 관련 DTO를 생성하였습니다.
- 게시물 목록 조회 API를 구현하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/#ALL-26-post-list -> dev
- close #27

<br/>

## 🔥 트러블 슈팅
### 문제
- PostListResponse DTO의 createdAt, updatedAt 필드를 어떤 타입으로 사용할지 고민하였습니다.<br><br>
### 분석
- **LocalDateTime 타입**
  - 장점
    1. 타입 안전성 - 날짜와 시간을 다루는 코드에서 숫자나 텍스트가 실수로 들어가는 것을 방지할 수 있습니다.
    2. 편리한 조작 - 날짜와 시간 조작을 위한 다양한 메서드를 제공합니다.
    3. 명확한 의미 - 해당 필드가 날짜 및 시간 타입임을 명시합니다.
  - 단점
    1. JSON 직렬화 형식 불일치 - 클라이언트와 서버 간의 날짜/시간 형식이 일치하지 않을 경우 추가 작업이 필요할 수 있습니다.
- **String 타입**
  - 장점
    1. 유연성 - 데이터의 형식이 고정되어 있지 않기 때문에 직렬화/역직렬화 작업에 있어 유연합니다.
    2. 호환성 - 클라이언트가 어떤 형식의 날짜를 사용하든, 문자열로 주고받기 때문에 형식 불일치로 인한 문제를 줄일 수 있습니다.
  - 단점
    1. 타입 안전성 부족 - 잘못된 형식의 문자열이 들어올 가능성이 있습니다.
    2. 파싱 필요 - LocalDateTime 등으로 파싱하는 작업이 필요하며, 코드의 복잡성을 증가시킬 수 있습니다.<br><br>
### 결과
- 날짜 및 시간 데이터의 정확한 의미와 안전성을 우선으로 두어 **LocalDateTime**을 채택하였습니다.
클라이언트와 서버 간의 직렬화 문제는 단점으로 작용할 수 있었지만, `@JsonFormat` 등의 추가적인 설정을 통해 충분히 해결할 수 있는 문제라고 판단하였습니다.
따라서, createdAt, updatedAt 필드 타입으로 LocalDateTime을 채택하기로 결정하였습니다.