### PR TITLE
[Feat] 통계 시간대별 API 서비스 로직 구현 및 통계 서비스 로직 메서드 통합

### DIFF
--- a/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
@@ -11,15 +11,16 @@ import java.util.List;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
-    @Query("SELECT DATE_FORMAT(pl.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+    @Query("SELECT DATE_FORMAT(pl.createdAt, :dateFormatPattern) AS time, count(*) AS value " +
             "FROM PostLike AS pl " +
             "WHERE pl.post.id in :postIds " +
             "AND DATE(pl.createdAt) BETWEEN :start AND :end " +
-            "GROUP BY DATE_FORMAT(pl.createdAt, '%Y-%m-%d') " +
+            "GROUP BY DATE_FORMAT(pl.createdAt, :dateFormatPattern) " +
             "ORDER BY time ASC")
-    List<StatisticQueryResponse> findDailyStatisticByPostIds(
+    List<StatisticQueryResponse> findStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
-            @Param("end") LocalDate end);
+            @Param("end") LocalDate end,
+            @Param("dateFormatPattern") String dateFormatPattern);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
@@ -11,15 +11,16 @@ import java.util.List;
 
 public interface PostShareRepository extends JpaRepository<PostShare, Long> {
 
-    @Query("SELECT DATE_FORMAT(ps.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+    @Query("SELECT DATE_FORMAT(ps.createdAt, :dateFormatPattern) AS time, count(*) AS value " +
             "FROM PostShare AS ps " +
             "WHERE ps.post.id in :postIds " +
             "AND DATE(ps.createdAt) BETWEEN :start AND :end " +
-            "GROUP BY DATE_FORMAT(ps.createdAt, '%Y-%m-%d') " +
+            "GROUP BY DATE_FORMAT(ps.createdAt, :dateFormatPattern) " +
             "ORDER BY time ASC")
-    List<StatisticQueryResponse> findDailyStatisticByPostIds(
+    List<StatisticQueryResponse> findStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
-            @Param("end") LocalDate end);
+            @Param("end") LocalDate end,
+            @Param("dateFormatPattern") String dateFormatPattern);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
@@ -11,15 +11,16 @@ import java.util.List;
 
 public interface PostViewRepository extends JpaRepository<PostView, Long> {
 
-    @Query("SELECT DATE_FORMAT(pv.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+    @Query("SELECT DATE_FORMAT(pv.createdAt, :dateFormatPattern) AS time, count(*) AS value " +
             "FROM PostView AS pv " +
             "WHERE pv.post.id in :postIds " +
             "AND DATE(pv.createdAt) BETWEEN :start AND :end " +
-            "GROUP BY DATE_FORMAT(pv.createdAt, '%Y-%m-%d') " +
+            "GROUP BY DATE_FORMAT(pv.createdAt, :dateFormatPattern) " +
             "ORDER BY time ASC")
-    List<StatisticQueryResponse> findDailyStatisticByPostIds(
+    List<StatisticQueryResponse> findStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
-            @Param("end") LocalDate end);
+            @Param("end") LocalDate end,
+            @Param("dateFormatPattern") String dateFormatPattern);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/controller/StatisticController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/StatisticController.java
@@ -37,13 +37,7 @@ public class StatisticController {
         log.info("type : " + type);
         log.info(start + "~" + end);
         log.info("value : " + value);
-        if (type == StatisticType.DATE) {
-            return statisticService.getStatisticsDaily(hashtag, type, start, end, value);
-
-        } else if (type == StatisticType.HOUR) {
-            return statisticService.getStatisticsHourly(hashtag, type, start, end, value);
-        }
-        return null;
+        return statisticService.getStatistics(hashtag, type, start, end, value);
     }
 
 }

--- a/src/main/java/com/allclear/socialhub/post/repository/PostRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/PostRepository.java
@@ -11,15 +11,16 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("SELECT DATE_FORMAT(p.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
+    @Query("SELECT DATE_FORMAT(p.createdAt, :dateFormatPattern) AS time, count(*) AS value " +
             "FROM Post AS p " +
             "WHERE p.id in :postIds " +
             "AND DATE(p.createdAt) BETWEEN :start AND :end " +
-            "GROUP BY DATE_FORMAT(p.createdAt, '%Y-%m-%d') " +
+            "GROUP BY DATE_FORMAT(p.createdAt, :dateFormatPattern) " +
             "ORDER BY time ASC")
-    List<StatisticQueryResponse> findDailyStatisticByPostIds(
+    List<StatisticQueryResponse> findStatisticByPostIds(
             @Param("postIds") List<Long> postIds,
             @Param("start") LocalDate start,
-            @Param("end") LocalDate end);
+            @Param("end") LocalDate end,
+            @Param("dateFormatPattern") String dateFormatPattern);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/service/StatisticService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/StatisticService.java
@@ -11,8 +11,6 @@ import java.util.List;
 @Service
 public interface StatisticService {
 
-    List<StatisticResponse> getStatisticsDaily(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value);
-
-    List<StatisticResponse> getStatisticsHourly(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value);
-
+    List<StatisticResponse> getStatistics(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value);
+    
 }

--- a/src/main/java/com/allclear/socialhub/post/service/StatisticServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/StatisticServiceImpl.java
@@ -13,9 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,8 +31,8 @@ public class StatisticServiceImpl implements StatisticService {
     private final PostViewRepository postViewRepository;
 
     /**
-     * 1. 일자별 통계
-     * 작성자 : 김효진
+     * 1. 통계
+     * 작성자 : 김효진, 김유현
      *
      * @param hashtag
      * @param type    : 일자별, 시간별
@@ -40,40 +42,132 @@ public class StatisticServiceImpl implements StatisticService {
      * @return List<StatisticDto>
      */
     @Override
-    public List<StatisticResponse> getStatisticsDaily(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value) {
+    public List<StatisticResponse> getStatistics(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value) {
 
+        // 1. 일자별 혹은 시간대별 날짜 포맷 패턴 설정
+        String queryDateFormatPattern = getQueryDateFormatPattern(type);
+
+        // 2. hashtag 테이블에서 해시태그 가진 게시물 리스트
         List<Long> postIds = hashTagRepository.getPostByHashtag(hashtag);
-        List<StatisticQueryResponse> responses = new ArrayList<>();
-        if (value.equals(StatisticValue.COUNT)) {
-            responses = postRepository.findDailyStatisticByPostIds(postIds, start, end);
-        } else if (value.equals(StatisticValue.LIKE_COUNT)) {
-            responses = postLikeRepository.findDailyStatisticByPostIds(postIds, start, end);
-        } else if (value.equals(StatisticValue.SHARE_COUNT)) {
-            responses = postShareRepository.findDailyStatisticByPostIds(postIds, start, end);
-        } else if (value.equals(StatisticValue.VIEW_COUNT)) {
-            responses = postViewRepository.findDailyStatisticByPostIds(postIds, start, end);
-        }
 
-        List<StatisticResponse> daily = getDaily(start, end);
-        for (StatisticResponse statisticResponse : daily) {
+        // 3. start ~ end 날짜로 일자별 혹은 시간대별 개수를 가져오는 쿼리 날린 결과
+        List<StatisticQueryResponse> queryResponses = getQueryResponsesByValue(value, postIds, start, end, queryDateFormatPattern);
+
+        // 4. 시간 - 개수 Map으로 변환
+        Map<String, Long> queryResponseMap = queryResponses.stream()
+                .collect(Collectors.toMap(StatisticQueryResponse::getTime, StatisticQueryResponse::getValue, (existing, replacement) -> existing));
+
+        // 5. 일자별 혹은 시간대별로 리스트 초기화
+        List<StatisticResponse> responses = initializeStatistics(type, start, end);
+
+        // 6. 시간 - 개수 Map에 존재하는 시간이면 개수를 매핑
+        for (StatisticResponse statisticResponse : responses) {
             String time = statisticResponse.getTime();
-            List<StatisticQueryResponse> filteredList = responses.stream().filter(it -> it.getTime().equals(time)).collect(Collectors.toList());
-            if (filteredList.size() > 0) {
-                statisticResponse.setValue(filteredList.get(0).getValue());
+            if (queryResponseMap.containsKey(time)) {
+                statisticResponse.setValue(queryResponseMap.get(time));
             }
         }
 
-        return daily;
+        return responses;
 
     }
 
-    private List<StatisticResponse> getDaily(LocalDate start, LocalDate end) {
+    /**
+     * 1-1. 통계 값에 따라 쿼리 결과를 가져옵니다.
+     * 작성자 : 김효진, 김유현
+     *
+     * @param value                  통계 값 (COUNT, LIKE_COUNT, VIEW_COUNT, SHARE_COUNT)
+     * @param postIds                통계 계산에 사용할 게시물 ID 리스트
+     * @param start                  통계 집계 시작 날짜
+     * @param end                    통계 집계 종료 날짜
+     * @param queryDateFormatPattern 날짜 포맷 패턴 (ex. '%Y-%m-%d', '%Y-%m-%d %H:%i')
+     * @return List<StatisticQueryResponse> 통계 데이터 리스트
+     */
+    private List<StatisticQueryResponse> getQueryResponsesByValue(StatisticValue value, List<Long> postIds, LocalDate start, LocalDate end, String queryDateFormatPattern) {
+
+        switch (value) {
+            case COUNT -> {
+                return postRepository.findStatisticByPostIds(postIds, start, end, queryDateFormatPattern);
+            }
+            case LIKE_COUNT -> {
+                return postLikeRepository.findStatisticByPostIds(postIds, start, end, queryDateFormatPattern);
+
+            }
+            case VIEW_COUNT -> {
+                return postViewRepository.findStatisticByPostIds(postIds, start, end, queryDateFormatPattern);
+
+            }
+            case SHARE_COUNT -> {
+                return postShareRepository.findStatisticByPostIds(postIds, start, end, queryDateFormatPattern);
+            }
+            default -> {
+                throw new IllegalArgumentException("잘못된 StatisticValue 입니다. value : " + value);
+            }
+        }
+    }
+
+    /**
+     * 1-2. 통계 유형에 따른 날짜 포맷 패턴을 반환합니다.
+     * 작성자 : 김유현
+     *
+     * @param type 통계 유형 (일자별 또는 시간별)
+     * @return String 날짜 포맷 패턴
+     */
+    private String getQueryDateFormatPattern(StatisticType type) {
+
+        switch (type) {
+            case DATE -> {
+                return "%Y-%m-%d";
+            }
+            case HOUR -> {
+                return "%Y-%m-%d %H:%i";
+            }
+            default -> {
+                throw new IllegalArgumentException("잘못된 StatisticType 입니다. type : " + type);
+            }
+        }
+    }
+
+    /**
+     * 1-3. 통계 유형에 따라 일자별 또는 시간별 데이터를 초기화합니다.
+     * 작성자 : 김유현
+     *
+     * @param type  통계 유형 (일자별 또는 시간별)
+     * @param start 시작 날짜
+     * @param end   종료 날짜
+     * @return List<StatisticResponse> 초기화된 통계 데이터 리스트
+     */
+    private List<StatisticResponse> initializeStatistics(StatisticType type, LocalDate start, LocalDate end) {
+
+        switch (type) {
+            case DATE -> {
+                return initializeDailyStatistics(start, end);
+            }
+            case HOUR -> {
+                return initializeHourlyStatistics(start, end);
+            }
+            default -> {
+                throw new IllegalArgumentException("잘못된 StatisticType 입니다. type : " + type);
+            }
+        }
+    }
+
+    /**
+     * 1-4. 주어진 기간에 대해 일자별 통계를 초기화합니다.
+     * 작성자 : 김효진
+     *
+     * @param start 시작 날짜
+     * @param end   종료 날짜
+     * @return List<StatisticResponse> 초기화된 일자별 통계 데이터 리스트 ex. [{2024-08-24 : 0}, ...]
+     */
+    private List<StatisticResponse> initializeDailyStatistics(LocalDate start, LocalDate end) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
         List<StatisticResponse> result = new ArrayList<>();
 
         List<LocalDate> localDates = new ArrayList<>();
         for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             // LocalDate를 문자열로 변환합니다.
             String formattedDate = date.format(formatter);
             StatisticResponse statisticResponse = new StatisticResponse(formattedDate, 0L);
@@ -85,20 +179,39 @@ public class StatisticServiceImpl implements StatisticService {
     }
 
     /**
-     * 2. 시간대별 통계
+     * 1-5. 주어진 기간에 대해 시간별 통계를 초기화합니다.
      * 작성자 : 김유현
      *
-     * @param hashtag
-     * @param type    : 일자별, 시간별
-     * @param start   : start date
-     * @param end     : end date
-     * @param value   : count, like_count, share_count, view_count
-     * @return List<StatisticDto>
+     * @param start 시작 날짜
+     * @param end   종료 날짜
+     * @return List<StatisticResponse> 초기화된 시간별 통계 데이터 리스트 ex. [{2024-08-24 00:00 : 0}, ...]
      */
-    @Override
-    public List<StatisticResponse> getStatisticsHourly(String hashtag, StatisticType type, LocalDate start, LocalDate end, StatisticValue value) {
+    public List<StatisticResponse> initializeHourlyStatistics(LocalDate start, LocalDate end) {
 
-        return null;
+        // 1. LocalDate를 LocalDateTime으로 변환하여 시작 시간과 끝 시간을 설정
+        //    시작 시간: start 날짜의 00:00 (하루의 시작)
+        //    끝 시간: end 날짜의 23:00
+        LocalDateTime startDateTime = start.atStartOfDay();
+        LocalDateTime endDateTime = end.atTime(23, 0);
+
+        // 2. 결과를 저장할 리스트를 초기화
+        List<StatisticResponse> result = new ArrayList<>();
+
+        // 3. 날짜와 시간의 포맷을 설정
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+        // 4. 시작 시간부터 끝 시간까지 1시간 단위로 반복
+        for (LocalDateTime dateTime = startDateTime; !dateTime.isAfter(endDateTime); dateTime = dateTime.plusHours(1)) {
+            // 5. 현재 LocalDateTime 객체를 문자열 형식으로 변환
+            //    포맷된 문자열은 "yyyy-MM-dd HH:mm" 형태로, 시간 단위로 구분
+            String formattedDateTime = dateTime.format(formatter);
+
+            // 6. 포맷된 문자열과 초기 값 0L을 사용하여 StatisticResponse 객체를 생성
+            StatisticResponse statisticResponse = new StatisticResponse(formattedDateTime, 0L);
+            result.add(statisticResponse);
+        }
+
+        return result;
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)

### 날짜 포맷 패턴 동적 처리 
- 일자별, 시간대별 dateFormat만 다르고 동일한 쿼리여서 동적 처리

<details>
<summary>before/after</summary>

(before)

```java
 @Query("SELECT DATE_FORMAT(pl.createdAt, '%Y-%m-%d') AS time, count(*) AS value " +
            "FROM PostLike AS pl " +
            "WHERE pl.post.id in :postIds " +
            "AND DATE(pl.createdAt) BETWEEN :start AND :end " +
            "GROUP BY DATE_FORMAT(pl.createdAt, '%Y-%m-%d') " +
            "ORDER BY time ASC")
    List<StatisticQueryResponse> findDailyStatisticByPostIds(
            @Param("postIds") List<Long> postIds,
            @Param("start") LocalDate start,
            @Param("end") LocalDate end);
```

(after)
```java
 @Query("SELECT DATE_FORMAT(pl.createdAt, :dateFormatPattern) AS time, count(*) AS value " +
            "FROM PostLike AS pl " +
            "WHERE pl.post.id in :postIds " +
            "AND DATE(pl.createdAt) BETWEEN :start AND :end " +
            "GROUP BY DATE_FORMAT(pl.createdAt, :dateFormatPattern) " +
            "ORDER BY time ASC")
    List<StatisticQueryResponse> findStatisticByPostIds(
            @Param("postIds") List<Long> postIds,
            @Param("start") LocalDate start,
            @Param("end") LocalDate end,
            @Param("dateFormatPattern") String dateFormatPattern);
```

</details>

### 통계 로직 개선

- Map을 사용하여 각 StatisticResponse 객체에 대한 시간 조회를 O(N*M) -> O(N)로 성능 향상

<details>
<summary>before/after</summary>
(before)

```java
       List<StatisticResponse> daily = getDaily(start, end);
        for (StatisticResponse statisticResponse : daily) {
            String time = statisticResponse.getTime();
            List<StatisticQueryResponse> filteredList = responses.stream().filter(it -> it.getTime().equals(time)).collect(Collectors.toList());
            if (filteredList.size() > 0) {
                statisticResponse.setValue(filteredList.get(0).getValue());
            }
        }
```

- daily 리스트의 각 항목에 대해 responses 리스트를 필터링
- 전체 루프의 시간 복잡도는 `O(M * N)`(M: daily 리스트의 크기, N은 responses 리스트의 크기)

(after)
```java
       // 4. 시간 - 개수 Map으로 변환
        Map<String, Long> queryResponseMap = queryResponses.stream()
                .collect(Collectors.toMap(StatisticQueryResponse::getTime, StatisticQueryResponse::getValue, (existing, replacement) -> existing));

        // 5. 일자별 혹은 시간대별로 리스트 초기화
        List<StatisticResponse> responses = initializeStatistics(type, start, end);

        // 6. 시간 - 개수 Map에 존재하는 시간이면 개수를 매핑
        for (StatisticResponse statisticResponse : responses) {
            String time = statisticResponse.getTime();
            if (queryResponseMap.containsKey(time)) {
                statisticResponse.setValue(queryResponseMap.get(time));
            }
        }
```
- Map으로 변환하는 작업 : `O(N)` 
- responses 리스트를 순회하면서 Map에서 값을 조회하는 작업은 : `O(M)`
- Map에서 값 조회 : `O(1)` 

</details>

### 기타
1. 클래스 및 메서드 이름 변경
- Dto 네이밍 컨벤션에 따라 클래스 이름 변경 
   - StatisticDto -> StatisticResponse 
   - 기존 StatisticResponse -> StatisticQueryResponse

- 일자별 통계와 시간대별 통계를 모두 처리하도록 수정함에 따라 getStatisticsDaily -> getStatistics 메서드 이름 변경 

2. value 타입 변경
- 개수를 나타내는 value를 double -> Long으로 변경

3. 메서드 분리 및 예외 처리
4. 메서드에 작성자 및 주석 추가

## 🌱 반영 브랜치
- Feat/#ALL-21-statistics-hourly -> Feat/#ALL-21-statistics
- #20 

<br/>
