### PR TITLE
[Feat] 게시물 수정 기능 개발

### DIFF
--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/repository/PostHashtagRepository.java
@@ -3,6 +3,10 @@ package com.allclear.socialhub.post.common.hashtag.repository;
 import com.allclear.socialhub.post.common.hashtag.domain.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+
+    List<PostHashtag> findAllByPostId(Long postId);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagService.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagService.java
@@ -8,6 +8,10 @@ import java.util.List;
 @Service
 public interface HashtagService {
 
-    List<Hashtag> toEachHashtag(List<String> hashtagList);
+    List<Hashtag> createHashtag(List<String> hashtagList);
+
+    List<Hashtag> updateHashtag(Long postId, List<String> hashtagList);
+
+    List<String> removeHashSymbol(List<String> hashtagList);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagServiceImpl.java
@@ -56,7 +56,6 @@ public class HashtagServiceImpl implements HashtagService {
         return savedHashtags;
     }
 
-
     /**
      * 해시태그 수정
      * 작성자 : 오예령

--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagServiceImpl.java
@@ -3,26 +3,127 @@ package com.allclear.socialhub.post.common.hashtag.service;
 import com.allclear.socialhub.common.exception.CustomException;
 import com.allclear.socialhub.common.exception.ErrorCode;
 import com.allclear.socialhub.post.common.hashtag.domain.Hashtag;
+import com.allclear.socialhub.post.common.hashtag.domain.PostHashtag;
 import com.allclear.socialhub.post.common.hashtag.repository.HashtagRepository;
+import com.allclear.socialhub.post.common.hashtag.repository.PostHashtagRepository;
+import com.querydsl.jpa.impl.JPADeleteClause;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.allclear.socialhub.post.common.hashtag.domain.QHashtag.hashtag;
+import static com.allclear.socialhub.post.common.hashtag.domain.QPostHashtag.postHashtag;
 
 @Service
 @RequiredArgsConstructor
 public class HashtagServiceImpl implements HashtagService {
 
     private final HashtagRepository hashtagRepository;
+    private final PostHashtagRepository postHashtagRepository;
+    private final EntityManager entityManager;
 
+    /**
+     * 해시태그 등록
+     * 작성자 : 오예령
+     *
+     * @param hashtagList
+     * @return
+     */
     @Override
-    public List<Hashtag> toEachHashtag(List<String> hashtagList) {
+    @Transactional
+    public List<Hashtag> createHashtag(List<String> hashtagList) {
 
         List<Hashtag> savedHashtags = new ArrayList<>();
 
         for (String content : hashtagList) {
 
+            // 3. 해시태그 중복 체크 및 저장
+            Hashtag hashtag = hashtagRepository.findByContent(content)
+                    .orElseGet(() -> hashtagRepository.save(
+                            Hashtag.builder()
+                                    .content(content)
+                                    .build()
+                    ));
+
+            savedHashtags.add(hashtag);
+        }
+
+        return savedHashtags;
+    }
+
+
+    /**
+     * 해시태그 수정
+     * 작성자 : 오예령
+     *
+     * @param postId
+     * @param hashtagList
+     * @return
+     */
+    @Override
+    @Transactional
+    public List<Hashtag> updateHashtag(Long postId, List<String> hashtagList) {
+
+        List<PostHashtag> postHashtags = postHashtagRepository.findAllByPostId(postId);
+
+        // 기존에 저장되어 있는 hastagList
+        List<String> originHashtagList = new ArrayList<>();
+        // 수정 요청한 hashtagList
+        List<String> compareHashtagList = removeHashSymbol(hashtagList);
+
+        for (PostHashtag postHashtag : postHashtags) {
+            originHashtagList.add(postHashtag.getHashtag().getContent());
+        }
+
+        // newHashtagList에 originHashtagList를 복사
+        List<String> newHashtagList = new ArrayList<>(originHashtagList);
+
+        // 기존에 저장되어 있던 값을 새로 요청온 값과 비교하여 중복된 값 제거 (해당 게시물에서 삭제할 해시태그)
+        originHashtagList.removeAll(compareHashtagList);
+
+        // hashtag 테이블에서 content로 찾되, content가 origin 안에 있는 값과 일치하는 경우 출력되는 hastagId
+        List<Long> ids = new JPAQueryFactory(entityManager)
+                .select(hashtag.id)
+                .from(hashtag)
+                .where(hashtag.content.in(originHashtagList))
+                .fetch();
+
+        // 해시태그 수정 후 더이상 존재하지 않는 값 삭제
+        deleteByPostIdAndHashtagIds(postId, ids);
+
+        compareHashtagList.removeAll(newHashtagList);
+
+        // 새로 추가해야 하는 해시태그 반환
+        return createHashtag(compareHashtagList);
+    }
+
+    @Transactional
+    public void deleteByPostIdAndHashtagIds(Long postId, List<Long> hashtagIds) {
+
+        JPADeleteClause deleteClause = new JPADeleteClause(entityManager, postHashtag);
+
+        deleteClause.where(
+                postHashtag.post.id.eq(postId)
+                        .and(postHashtag.hashtag.id.in(hashtagIds))
+        ).execute();
+    }
+
+    /**
+     * 해시태그 검증 및 '#' 삭제
+     * 작성자 : 오예령
+     *
+     * @param hashtagList
+     * @return '#'가 삭제된 hashtagList 반환
+     */
+    public List<String> removeHashSymbol(List<String> hashtagList) {
+
+        List<String> cleanedHashtagList = new ArrayList<>();
+        for (String content : hashtagList) {
             // 1. 해시태그 형식 검증
             // '#'이 정확히 하나로 시작해야 하고, 그 뒤에 텍스트가 있어야 함
             if (!content.matches("^#[^#]+$")) {
@@ -31,19 +132,9 @@ public class HashtagServiceImpl implements HashtagService {
 
             // 2. '#' 제거
             String cleanedContent = content.substring(1);
-
-            // 3. 해시태그 중복 체크 및 저장
-            Hashtag hashtag = hashtagRepository.findByContent(cleanedContent)
-                    .orElseGet(() -> hashtagRepository.save(
-                            Hashtag.builder()
-                                    .content(cleanedContent)
-                                    .build()
-                    ));
-
-            savedHashtags.add(hashtag);
+            cleanedHashtagList.add(cleanedContent);
         }
-
-        return savedHashtags;
+        return cleanedHashtagList;
     }
 
 }

--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.allclear.socialhub.post.controller;
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostPaging;
 import com.allclear.socialhub.post.dto.PostResponse;
+import com.allclear.socialhub.post.dto.PostUpdateRequest;
 import com.allclear.socialhub.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -17,7 +18,7 @@ public class PostController {
 
     private final PostService postService;
 
-    @RequestMapping(value = "", method = RequestMethod.POST)
+    @PostMapping
     public ResponseEntity<PostResponse> creatPost(@RequestBody PostCreateRequest requestDto) {
 
         // TODO : 유저 받아오는 형식 추후 변경 예정
@@ -29,6 +30,13 @@ public class PostController {
 
         return ResponseEntity.status(200).body(postService.getPosts(pageable));
 
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponse> updatePost(@RequestBody PostUpdateRequest updateRequest,
+                                                   @PathVariable Long postId) {
+
+        return ResponseEntity.status(200).body(postService.updatePost(1L, postId, updateRequest));
     }
 
 }

--- a/src/main/java/com/allclear/socialhub/post/domain/Post.java
+++ b/src/main/java/com/allclear/socialhub/post/domain/Post.java
@@ -43,4 +43,10 @@ public class Post extends Timestamped {
     @Column(nullable = false)
     private int shareCnt;
 
+    public void update(Post updatePost) {
+
+        this.title = updatePost.getTitle();
+        this.content = updatePost.getContent();
+    }
+
 }

--- a/src/main/java/com/allclear/socialhub/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.allclear.socialhub.post.dto;
+
+import com.allclear.socialhub.post.domain.Post;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostUpdateRequest {
+
+    private String title;
+    private String content;
+    private List<String> hashtagList;
+
+    public Post toEntity() {
+
+        return Post.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+
+}

--- a/src/main/java/com/allclear/socialhub/post/service/PostService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostService.java
@@ -1,17 +1,19 @@
 package com.allclear.socialhub.post.service;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostPaging;
 import com.allclear.socialhub.post.dto.PostResponse;
+import com.allclear.socialhub.post.dto.PostUpdateRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 
 @Service
 public interface PostService {
 
-	PostResponse createPost(Long userId, PostCreateRequest requestDto);
+    PostResponse createPost(Long userId, PostCreateRequest requestDto);
 
-	PostPaging getPosts(Pageable pageable);
+    PostResponse updatePost(Long userId, Long postId, PostUpdateRequest updateRequest);
+
+    PostPaging getPosts(Pageable pageable);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -9,19 +9,25 @@ import com.allclear.socialhub.post.domain.Post;
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostPaging;
 import com.allclear.socialhub.post.dto.PostResponse;
+import com.allclear.socialhub.post.dto.PostUpdateRequest;
 import com.allclear.socialhub.post.repository.PostRepository;
 import com.allclear.socialhub.user.domain.User;
 import com.allclear.socialhub.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static com.allclear.socialhub.common.exception.ErrorCode.POST_NOT_FOUND;
 import static com.allclear.socialhub.common.exception.ErrorCode.USER_NOT_EXIST;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostServiceImpl implements PostService {
 
     private final UserRepository userRepository;
@@ -30,7 +36,7 @@ public class PostServiceImpl implements PostService {
     private final PostHashtagRepository postHashtagRepository;
 
     /**
-     * 1. 게시물 등록
+     * 0. 게시물 등록
      * 작성자 : 오예령
      *
      * @param createRequest
@@ -38,25 +44,81 @@ public class PostServiceImpl implements PostService {
      */
     @Override
     public PostResponse createPost(Long userId, PostCreateRequest createRequest) {
-        // 1. 유저 검증
-        User user = userRepository.findById(userId).orElseThrow(
-                () -> new CustomException(USER_NOT_EXIST)
-        );
-        // 2. 게시물 등록
+
+        // 0. 유저 검증
+        User user = userCheck(userId);
+
+        // 1. 게시물 등록
         Post post = postRepository.save(createRequest.toEntity(user));
 
-        // 3. 해시태그 등록
-        List<Hashtag> savedHashtags = hashtagService.toEachHashtag(createRequest.getHashtagList());
+        // 2. 해시태그 등록
+        List<String> cleanedHashtagList = hashtagService.removeHashSymbol(createRequest.getHashtagList());
+        List<Hashtag> savedHashtags = hashtagService.createHashtag(cleanedHashtagList);
 
-        for (Hashtag hashtag : savedHashtags) {
-            PostHashtag postHashtag = PostHashtag.builder()
+        // 3. 연관관계 등록
+        savePostHashtag(post, savedHashtags);
+
+        return PostResponse.fromEntity(post, createRequest.getHashtagList());
+    }
+
+    /**
+     * 1. 게시물 수정
+     * 작성자 : 오예령
+     *
+     * @param userId
+     * @param postId
+     * @param updateRequest
+     * @return 수정된 게시물 PostResponse에 담아 반환
+     */
+    @Override
+    @Transactional
+    public PostResponse updatePost(Long userId, Long postId, PostUpdateRequest updateRequest) {
+
+        // 0. 유저 검증
+        userCheck(userId);
+
+        // 1. 게시물 검증
+        Post post = postCheck(postId);
+
+        Post updatePost = updateRequest.toEntity();
+        post.update(updatePost);
+
+        // 2. 해시태그 수정
+        List<Hashtag> savedHashtags = hashtagService.updateHashtag(postId, updateRequest.getHashtagList());
+
+        // 3. 연관관계 수정
+        savePostHashtag(post, savedHashtags);
+
+        // 4. 수정된 hashtagList 반환
+        List<String> updatedHashtagList = new ArrayList<>();
+
+        List<PostHashtag> postHashtags = postHashtagRepository.findAllByPostId(postId);
+
+        for (PostHashtag postHashtag : postHashtags) {
+            updatedHashtagList.add("#" + postHashtag.getHashtag().getContent());
+        }
+
+        return PostResponse.fromEntity(post, updatedHashtagList);
+    }
+
+    /**
+     * PostHashtag 연관관계 등록
+     * 작성자 : 오예령
+     *
+     * @param post
+     * @param hashtags
+     */
+    private void savePostHashtag(Post post, List<Hashtag> hashtags) {
+
+        for (Hashtag hashtag : hashtags) {
+            PostHashtag postHashTag = PostHashtag.builder()
                     .post(post)
                     .hashtag(hashtag)
                     .build();
-            postHashtagRepository.save(postHashtag);
+            postHashtagRepository.save(postHashTag);
         }
-        return PostResponse.fromEntity(post, createRequest.getHashtagList());
     }
+
 
     /**
      * 5. 게시물 목록 조회
@@ -68,6 +130,34 @@ public class PostServiceImpl implements PostService {
     public PostPaging getPosts(Pageable pageable) {
 
         return new PostPaging(postRepository.getPosts(pageable));
+    }
+
+    /**
+     * 회원 검증
+     * 작성자 : 오예령
+     *
+     * @param userId
+     * @return
+     */
+    private User userCheck(Long userId) {
+
+        return userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(USER_NOT_EXIST)
+        );
+    }
+
+    /**
+     * 게시물 검증
+     * 작성자 : 오예령
+     *
+     * @param postId
+     * @return
+     */
+    private Post postCheck(Long postId) {
+
+        return postRepository.findById(postId).orElseThrow(
+                () -> new CustomException(POST_NOT_FOUND)
+        );
     }
 
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -39,7 +39,7 @@ public class PostServiceImpl implements PostService {
      * 0. 게시물 등록
      * 작성자 : 오예령
      *
-     * @param createRequest
+     * @param createRequest 게시물 타입, 제목, 내용, 해시태그리스트
      * @return 생성된 게시물 PostResponse에 담아 반환
      */
     @Override
@@ -65,9 +65,9 @@ public class PostServiceImpl implements PostService {
      * 1. 게시물 수정
      * 작성자 : 오예령
      *
-     * @param userId
-     * @param postId
-     * @param updateRequest
+     * @param userId        유저Id
+     * @param postId        게시물Id
+     * @param updateRequest 게시물 제목, 내용, 해시태그리스트
      * @return 수정된 게시물 PostResponse에 담아 반환
      */
     @Override
@@ -105,17 +105,17 @@ public class PostServiceImpl implements PostService {
      * PostHashtag 연관관계 등록
      * 작성자 : 오예령
      *
-     * @param post
-     * @param hashtags
+     * @param post     게시물
+     * @param hashtags 해시태그
      */
     private void savePostHashtag(Post post, List<Hashtag> hashtags) {
 
         for (Hashtag hashtag : hashtags) {
-            PostHashtag postHashTag = PostHashtag.builder()
+            PostHashtag postHashtag = PostHashtag.builder()
                     .post(post)
                     .hashtag(hashtag)
                     .build();
-            postHashtagRepository.save(postHashTag);
+            postHashtagRepository.save(postHashtag);
         }
     }
 
@@ -136,7 +136,7 @@ public class PostServiceImpl implements PostService {
      * 회원 검증
      * 작성자 : 오예령
      *
-     * @param userId
+     * @param userId 유저Id
      * @return 해당 회원을 반환
      */
     private User userCheck(Long userId) {
@@ -150,7 +150,7 @@ public class PostServiceImpl implements PostService {
      * 게시물 검증
      * 작성자 : 오예령
      *
-     * @param postId
+     * @param postId 게시물Id
      * @return 해당 게시물을 반환
      */
     private Post postCheck(Long postId) {

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -137,7 +137,7 @@ public class PostServiceImpl implements PostService {
      * 작성자 : 오예령
      *
      * @param userId
-     * @return
+     * @return 해당 회원을 반환
      */
     private User userCheck(Long userId) {
 
@@ -151,7 +151,7 @@ public class PostServiceImpl implements PostService {
      * 작성자 : 오예령
      *
      * @param postId
-     * @return
+     * @return 해당 게시물을 반환
      */
     private Post postCheck(Long postId) {
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 게시물 수정 기능 개발하였습니다.
- 해시태그 수정 시 기존의 해시태그와 비교하여 중복되지 않는 값들은 DB에서 중복 조회한 뒤 생성하였고, 중복되는 값들은 별도의 처리 없이 유지되도록 하였습니다.
- 기존에 등록되었던 해시태그이지만 새롭게 수정된 해시태그에 해당하지 않는 경우에는 별도로 삭제하지 않고 PostHash 테이블에서 연관관계만 삭제하였습니다.

## 🌱 반영 브랜치

- feat/#ALL-23-post-update -> dev
- close #33 

<br/>

## 🔥 트러블 슈팅 (선택)
### 코드 진행의 이해
-  연관관계를 고려하여 개발하기 위해 슈도 코드를 작성해 로직의 흐름을 구상하여 한 단계 한 단계 개발하였습니다.
 > 1. postHashtag 테이블에서 postId를 통해 hastagId 조회
> 2. hashtag 테이블에서 위에서 조회한 id로 내용을 조회
> 3. 새로 요청한 updateRequest.getHashtagList() 값과 비교
> 4. 일치하지 않는 경우에는 postHashtag 테이블에서 행 삭제

### 연관관계로 인한 코드  복잡성

- 해시태그 수정 시 기존에 등록되었던 값이 수정 시에는 삭제 해야하는 경우 Hashtag 테이블에서는 삭제되지 않고, PostHashtag 테이블에서 해당 게시물의 해당 해시태그만 삭제 되도록 구현하는 부분에서 많은 고민을 했습니다.
- 반복문을 통해 기능구현은 가능하지만 해시태그의 개수가 많은 경우 처리량이 증가해 서비스 실행 면으로 보았을 때 비효율적이라는 판단을 했습니다.
- 아래 코드처럼 JPA가 제공하는 Querydsl 기능을 활용해 비교적 간단히 조건을 걸어 삭제하고자 하는 해시태그 id 값들을 구할 수 있었고, 연관관계 또한 JPADeleteClause를 활용해 간단히 삭제하였습니다.

         @Override
         @Transactional
         public List<Hashtag> updateHashtag(Long postId, List<String> hashtagList) {

         ...

         List<Long> ids = new JPAQueryFactory(entityManager)
                .select(hashtag.id)
                .from(hashtag)
                .where(hashtag.content.in(originHashtagList))
                .fetch();

        // 해시태그 수정 후 더이상 존재하지 않는 값 삭제
        deleteByPostIdAndHashtagIds(postId, ids);

        compareHashtagList.removeAll(newHashtagList);

        ....

      }

        @Transactional
         public void deleteByPostIdAndHashtagIds(Long postId, List<Long> hashtagIds) {

            JPADeleteClause deleteClause = new JPADeleteClause(entityManager, postHashtag);

            deleteClause.where(
                   postHashtag.post.id.eq(postId)
                          .and(postHashtag.hashtag.id.in(hashtagIds))
            ).execute();
       }

