### PR TITLE
[Chore] yml 파일 내 테스트 전용 프로파일 분리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,69 @@
+# 1. 기본값 프로파일
 spring:
   application:
     name: socialhub
+
+  profiles:
+    default: local # (로컬로 지정)
+
   # .env import
   config:
     import: optional:file:.env[.properties]
+
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     open-in-view: true
     hibernate:
-      ddl-auto: update
       naming:
         use-new-id-generator-mappings: false
     show-sql: true
     properties:
       hibernate:
+        ddl-auto: none
         id:
           new_generator_mappings: true
-      hibernate.format_sql: true
       dialect: org.hibernate.dialect.MySQL5InnoDBDialect
-    defer-datasource-initialization: true
+
+# 2. 로컬용 프로파일 (보통 배포 전 초기 개발 단계에 사용)
+---
+spring:
+  config:
+    activate:
+      on-profile: local # 프로파일명
+
+  jpa:
+    hibernate:
+      ddl-auto: create # 서버 실행 시 DB의 모든 테이블 삭제 후 재생성
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true # (2.5~) Hibernate 초기화 이후 data.sql 실행
+
   sql:
     init:
-      mode: never #always 한 번 사용 후 never로
+      mode: always # 서버 실행 시 data.sql 파일 항상 실행
+
+# 3. 테스트 실행 전용 프로파일
+---
+spring:
+  config:
+    activate:
+      on-profile: test # 프로파일명 (@ActiveProfiles("test") 어노테이션을 부착한 테스트 클래스만 테스트 환경으로 실행)
+
+  jpa:
+    hibernate:
+      ddl-auto: create # 테스트 실행 시 DB의 모든 테이블 삭제 후 재생성
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: never # 테스트 실행 시 data.sql 파일 실행하지 않음


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- yml 파일 내에 로컬 환경과 테스트 환경의 프로파일을 분리하였습니다.

<br/>

## 🌱 반영 브랜치
- chore/#ALL-65-yml-profile-setting -> dev
- close #63 

<br/>

## 🔥 트러블 슈팅 (선택)
### 고민한 내용
- yml 파일 내에 로컬 환경과 테스트 환경의 프로파일 분리가 필요할 것인가 고민하였습니다.

<br/>

### 고민한 이유
- `게시물 목록 조회 테스트 메서드 : A`, `게시물 등록 테스트 메서드 : B` 라고 가정했을 때,
게시물 관련 테스트 클래스에는 `A`와 `B`가 함께 존재하며, `A`에는 반환된 게시물의 필드를 검증하는 부분이 있습니다.
ex) 게시물의 제목, 내용, ....

이 때, 프로파일을 분리하지 않고 해당 테스트 클래스 전체 실행 시, `B`보다 아래 라인에 있는 `A`의 결과가 `B`의 영향을 받았습니다.
(게시물 등록 테스트가 먼저 실행되면서 DB에 새로운 게시물 행이 추가되어 게시물 목록 조회 테스트는 실패하게 됩니다.)
- 예시
1. 목록 조회 검증 코드
```java
  Assertions.assertThat(postService.getPosts(pageable).getPostList()).hasSize(3)
                .extracting("title", "content")
                .containsExactlyInAnyOrder(
                        tuple("테스트 제목", "테스트 내용"),
                        tuple("테스트 제목", "테스트 내용"),
                        tuple("망원동 맛집", "맛집 소개")
                );
```
2. 테스트에서 기대하는 게시물 제목 리스트 : "테스트 제목", "테스트 제목", "망원동 맛집"
3. DB에 저장되어 있는 게시물 제목 리스트 : "테스트 제목", "테스트 제목", "테스트 제목" `(B로 인해 새로 등록된 게시물)`

- 프로파일을 분리하지 않을 시, 위의 예시처럼 테스트 실행 순서에 영향을 받아 테스트의 검증이 일관되지 않거나, 때에 따라 실패하는 문제가 발생했습니다.

<br/>

### 결과
- 모든 테스트는 테스트 실행 순서에 상관없이 항상 성공해야 하며, 각 테스트 간의 독립성이 보장되어야 합니다.
따라서, 신뢰성 있는 테스트 코드를 작성하고자 yml 파일 내에 local 프로파일과 test 전용 프로파일을 추가하여 로컬과 테스트 환경을 분리하였습니다.