### PR TITLE
[Test] 게시물 목록 조회 기능 테스트

### DIFF
--- a/src/main/java/com/allclear/socialhub/post/dto/PostPaging.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostPaging.java
@@ -1,5 +1,6 @@
 package com.allclear.socialhub.post.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PostPaging {
 
     private int postCnt;

--- a/src/test/java/com/allclear/socialhub/post/controller/PostControllerTest.java
+++ b/src/test/java/com/allclear/socialhub/post/controller/PostControllerTest.java
@@ -1,0 +1,75 @@
+package com.allclear.socialhub.post.controller;
+
+import com.allclear.socialhub.post.dto.PostPaging;
+import com.allclear.socialhub.post.dto.PostResponse;
+import com.allclear.socialhub.post.service.PostServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PostController.class)
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PostServiceImpl postService;
+
+    @DisplayName("게시물 목록을 조회합니다.")
+    @Test
+    void getPosts() throws Exception {
+        // given
+        List<PostResponse> postList = List.of(
+                new PostResponse(1L, 1L, "망원동 맛집", "맛집 소개해요",
+                        List.of("#망원동", "#맛집"), 10, 10, 10,
+                        LocalDateTime.of(2024, 8, 25, 12, 0, 0),
+                        LocalDateTime.of(2024, 8, 25, 12, 0, 0)),
+                new PostResponse(2L, 1L, "영화 추천", "영화 추천합니다",
+                        List.of("#영화", "#해리포터"), 20, 20, 20,
+                        LocalDateTime.of(2024, 8, 25, 12, 0, 0),
+                        LocalDateTime.of(2024, 8, 25, 12, 0, 0))
+        );
+
+        PostPaging postPaging = new PostPaging(2, postList, 10, 0, 1);
+        ResponseEntity<PostPaging> result = new ResponseEntity<>(postPaging, HttpStatus.OK);
+
+        when(postService.getPosts(any(Pageable.class))).thenReturn(result.getBody());
+
+        // when // then
+        mockMvc.perform(get("/api/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "0")
+                        .param("pageSize", "10")
+                        .param("sort", "postId,DESC"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.postCnt").value(2))
+                .andExpect(jsonPath("$.postList[0].postId").value(1))
+                .andExpect(jsonPath("$.postList[0].title").value("망원동 맛집"))
+                .andExpect(jsonPath("$.postList[0].content").value("맛집 소개해요"))
+                .andExpect(jsonPath("$.postList[1].postId").value(2))
+                .andExpect(jsonPath("$.postList[1].title").value("영화 추천"))
+                .andExpect(jsonPath("$.postList[1].content").value("영화 추천합니다"));
+
+        verify(postService).getPosts(any(Pageable.class));
+
+    }
+
+}

--- a/src/test/java/com/allclear/socialhub/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/allclear/socialhub/post/service/PostServiceImplTest.java
@@ -1,76 +1,148 @@
 package com.allclear.socialhub.post.service;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.allclear.socialhub.common.exception.CustomException;
 import com.allclear.socialhub.common.exception.ErrorCode;
+import com.allclear.socialhub.post.common.hashtag.repository.HashtagRepository;
+import com.allclear.socialhub.post.common.hashtag.repository.PostHashtagRepository;
+import com.allclear.socialhub.post.domain.Post;
 import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostResponse;
+import com.allclear.socialhub.post.repository.PostRepository;
 import com.allclear.socialhub.user.domain.User;
 import com.allclear.socialhub.user.repository.UserRepository;
 import com.allclear.socialhub.user.type.UserCertifyStatus;
 import com.allclear.socialhub.user.type.UserStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static com.allclear.socialhub.post.domain.PostType.*;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ActiveProfiles("test")
 @SpringBootTest
 class PostServiceImplTest {
 
-	@Autowired
-	private UserRepository userRepository;
-	@Autowired
-	private PostServiceImpl postService;
+    @Autowired
+    private UserRepository userRepository;
 
-	@BeforeEach
-	@Transactional
-	public void beforeEach() {
+    @Autowired
+    private PostServiceImpl postService;
 
-		User user = User.builder()
-				.id(1L)
-				.username("testUsername")
-				.email("testEmail@test.com")
-				.password("testPassword@")
-				.status(UserStatus.ACTIVE)
-				.certifyStatus(UserCertifyStatus.AUTHENTICATED)
-				.build();
-		userRepository.save(user);
+    @Autowired
+    private PostHashtagRepository postHashtagRepository;
 
-	}
+    @Autowired
+    private HashtagRepository hashtagRepository;
 
-	@Test
-	@DisplayName("게시물을 등록합니다.")
-	void createPost() {
-		// given
-		User user = userRepository.findById(1L).orElseThrow(
-				() -> new CustomException(ErrorCode.USER_NOT_EXIST)
-		);
+    @Autowired
+    private PostRepository postRepository;
 
-		List<String> hashtagList = Arrays.asList("#테스트", "#자바", "#스프링");
+    @AfterEach
+    void tearDown() {
 
-		PostCreateRequest request = PostCreateRequest.builder()
-				.type(PostType.INSTAGRAM)
-				.title("테스트제목")
-				.content("테스트내용")
-				.hashtagList(hashtagList)
-				.build();
+        postHashtagRepository.deleteAllInBatch();
+        hashtagRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
 
-		// when
-		PostResponse response = postService.createPost(user.getId(), request);
+    }
 
-		// then
-		assertNotNull(response);
-		assertEquals("테스트제목", response.getTitle());
-		assertEquals("테스트내용", response.getContent());
-		assertEquals(3, response.getHashtagList().size());
-	}
+    @Test
+    @DisplayName("게시물을 등록합니다.")
+    void createPost() {
+        // given
+        User user = createUser();
+
+        user = userRepository.findById(1L).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_EXIST)
+        );
+
+        List<String> hashtagList = Arrays.asList("#테스트", "#자바", "#스프링");
+
+        PostCreateRequest request = PostCreateRequest.builder()
+                .type(INSTAGRAM)
+                .title("테스트제목")
+                .content("테스트내용")
+                .hashtagList(hashtagList)
+                .build();
+
+        // when
+        PostResponse response = postService.createPost(user.getId(), request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("테스트제목", response.getTitle());
+        assertEquals("테스트내용", response.getContent());
+        assertEquals(3, response.getHashtagList().size());
+    }
+
+    @DisplayName("게시물 목록을 조회합니다.")
+    @Test
+    void getPosts() {
+        // given
+        Pageable pageable = PageRequest.of(0, 3, Sort.by(Sort.Order.desc("id")));
+
+        User user = createUser();
+
+        Post post1 = createPost(user, "제목1", "내용1", INSTAGRAM, 10, 10, 10);
+        Post post2 = createPost(user, "제목2", "내용2", FACEBOOK, 20, 20, 20);
+        Post post3 = createPost(user, "제목3", "내용3", TWITTER, 30, 30, 30);
+
+        postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+        // when // then
+        Assertions.assertThat(postService.getPosts(pageable).getPostList()).hasSize(3)
+                .extracting("title", "content", "type", "likeCnt", "shareCnt", "viewCnt")
+                .containsExactlyInAnyOrder(
+                        tuple("제목3", "내용3", TWITTER, 30, 30, 30),
+                        tuple("제목2", "내용2", FACEBOOK, 20, 20, 20),
+                        tuple("제목1", "내용1", INSTAGRAM, 10, 10, 10)
+                );
+    }
+
+    // 유저 빌더 생성
+    private User createUser() {
+
+        User user = User.builder()
+                .username("testUsername")
+                .email("testEmail@test.com")
+                .password("testPassword@")
+                .status(UserStatus.ACTIVE)
+                .certifyStatus(UserCertifyStatus.AUTHENTICATED)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    // 게시물 빌더 생성
+    private Post createPost(User user, String title, String content, PostType type,
+                            int viewCnt, int likeCnt, int shareCnt) {
+
+        return Post.builder()
+                .user(user)
+                .title(title)
+                .content(content)
+                .type(type)
+                .viewCnt(viewCnt)
+                .likeCnt(likeCnt)
+                .shareCnt(shareCnt)
+                .build();
+    }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 게시물 목록 조회 Service 계층 테스트를 진행하였습니다.
- 게시물 목록 조회 Controller 계층 테스트를 진행하였습니다.

<br/>

## 🌱 반영 브랜치
- test/#ALL-56-post-list-test -> dev
- close #48 

<br/>

## 🔥 트러블 슈팅 (선택)
### 문제 1.
- Service 테스트에서 게시물 등록 테스트가 다음 테스트인 게시물 목록 조회 테스트에 영향을 주는 경우가 발생했습니다.
### 분석 1.
- 각 테스트는 독립적으로 실행되어야 하며, 하나의 테스트가 실행된 후 다른 테스트에 영향을 주지 않아야 한다고 판단하였습니다.
### 결과 1.
- `@BeforeEach`를 제거하고, `@AfterEach`의 `tearDown()` 메서드를 추가하여 각 테스트 후 데이터 클렌징 작업을 수행하도록 하였습니다. 이를 통해 개별 테스트 간에 영향을 방지하였습니다.

<br/>

### 문제 2.
- 게시물 목록 조회 Service 테스트 코드에서 `User`와 `Post`를 생성하는 빌더 코드가 반복적으로 작성되었습니다.
### 분석 2.
- 동일한 객체를 여러 번 생성하는 경우, 객체 생성 코드를 별도로 관리하는 것이 유지보수에 더 효과적이라고 판단하였습니다.
### 결과 2.
- 공통으로 사용되는 `User`와 `Post`를 생성하는 빌더를 별도로 분리하여 코드의 중복을 제거하고 유지보수성을 향상시켰습니다.