### PR TITLE
[Feat] 통계 jwt 인증 기능 개발

### DIFF
--- a/src/main/java/com/allclear/socialhub/common/provider/JwtTokenProvider.java
+++ b/src/main/java/com/allclear/socialhub/common/provider/JwtTokenProvider.java
@@ -1,68 +1,88 @@
 package com.allclear.socialhub.common.provider;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
-
-import javax.crypto.SecretKey;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import com.allclear.socialhub.user.domain.User;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
 
-	@Value("${JWT_SECRET_KEY}")
-	private String SECRET_KEY;
+    @Value("${JWT_SECRET_KEY}")
+    private String SECRET_KEY;
 
-	/**
-	 * 1. 문자열을 SecretKey 타입으로 변환
-	 * 작성자 : 김은정
-	 * @return SecretKey key
-	 */
-	private SecretKey getSigningKey() {
-		byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
-		return Keys.hmacShaKeyFor(keyBytes);
-	}
+    /**
+     * 1. 문자열을 SecretKey 타입으로 변환
+     * 작성자 : 김은정
+     *
+     * @return SecretKey key
+     */
+    private SecretKey getSigningKey() {
 
-	/**
-	 * 2. JWT 토큰 생성
-	 * 작성자 : 김은정
-	 * @param user
-	 * @return String jwtToken
-	 */
-	public String createToken(User user) {
-		Date expiryDate = Date.from(
-				Instant.now().plus(1, ChronoUnit.HOURS)
-		);
-		String sub = user.getUsername() + "," + user.getEmail();
+        byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
 
-		return Jwts.builder()
-				.subject(sub)
-				.issuedAt(new Date())
-				.expiration(expiryDate)
-				.signWith(this.getSigningKey())
-				.compact();
-	}
+    /**
+     * 2. JWT 토큰 생성
+     * 작성자 : 김은정
+     *
+     * @param user
+     * @return String jwtToken
+     */
+    public String createToken(User user) {
 
-	/**
-	 * 3. JWT 토큰에서 Payload 추출
-	 * 작성자 : 김은정
-	 * @param token
-	 * @return Claims payload
-	 */
-	public Claims extractAllClaims(String token) {
-		return Jwts.parser()
-				.verifyWith(this.getSigningKey())
-				.build()
-				.parseSignedClaims(token)
-				.getPayload();
-	}
+        Date expiryDate = Date.from(
+                Instant.now().plus(1, ChronoUnit.HOURS)
+        );
+        String sub = user.getUsername() + "," + user.getEmail();
+
+        return Jwts.builder()
+                .subject(sub)
+                .issuedAt(new Date())
+                .expiration(expiryDate)
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    /**
+     * 3. JWT 토큰에서 Payload 추출
+     * 작성자 : 김은정
+     *
+     * @param token
+     * @return Claims payload
+     */
+    public Claims extractAllClaims(String token) {
+
+        return Jwts.parser()
+                .verifyWith(this.getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * 3. JWT 토큰에서 Payload 의 username 추출
+     * 작성자 : 김효진
+     *
+     * @param token
+     * @return String   username
+     */
+    public String extractAccountFromToken(String token) {
+
+        Claims claims = this.extractAllClaims(token);
+        String payload = claims.getSubject();
+        String[] result = payload.split(",");
+        String username = result[0].trim();
+        return username;
+    }
+
 }

--- a/src/main/java/com/allclear/socialhub/post/controller/StatisticController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/StatisticController.java
@@ -1,5 +1,6 @@
 package com.allclear.socialhub.post.controller;
 
+import com.allclear.socialhub.common.provider.JwtTokenProvider;
 import com.allclear.socialhub.post.domain.StatisticType;
 import com.allclear.socialhub.post.domain.StatisticValue;
 import com.allclear.socialhub.post.dto.StatisticRequestParam;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,11 +25,21 @@ import java.util.List;
 public class StatisticController {
 
     private final StatisticService statisticService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping
-    public ResponseEntity<List<StatisticResponse>> getStatistics(@Valid StatisticRequestParam statisticRequest) {
+    public ResponseEntity<List<StatisticResponse>> getStatistics(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Valid StatisticRequestParam statisticRequest
+    ) {
 
-        // TODO: hashtag = null일 경우 본인계정으로 설정
+        // JWT 토큰 추출
+        String token = authorizationHeader.substring(7); // "Bearer " 부분 제거
+        String username = jwtTokenProvider.extractAccountFromToken(token);
+        // hashtag가 없으면 JWT 토큰에서 추출한 사용자 이름 설정
+        if (statisticRequest.getHashtag() == null) {
+            statisticRequest.setHashtag(username);
+        }
 
         String hashtag = statisticRequest.getHashtag();
         StatisticType type = statisticRequest.getType();

--- a/src/main/java/com/allclear/socialhub/post/controller/StatisticController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/StatisticController.java
@@ -6,6 +6,8 @@ import com.allclear.socialhub.post.domain.StatisticValue;
 import com.allclear.socialhub.post.dto.StatisticRequestParam;
 import com.allclear.socialhub.post.dto.StatisticResponse;
 import com.allclear.socialhub.post.service.StatisticService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,11 +24,13 @@ import java.util.List;
 @RequestMapping("/api/posts/statistics")
 @Slf4j
 @RequiredArgsConstructor
+@Tag(name = "Statistics", description = "통계 API")
 public class StatisticController {
 
     private final StatisticService statisticService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(summary = "통계 조회", description = "일자별, 시간별 통계를 조회합니다.")
     @GetMapping
     public ResponseEntity<List<StatisticResponse>> getStatistics(
             @RequestHeader("Authorization") String authorizationHeader,

--- a/src/main/java/com/allclear/socialhub/post/dto/StatisticRequestParam.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/StatisticRequestParam.java
@@ -4,10 +4,12 @@ import com.allclear.socialhub.post.domain.StatisticType;
 import com.allclear.socialhub.post.domain.StatisticValue;
 import jakarta.validation.constraints.PastOrPresent;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
+@Setter
 @Getter
 public class StatisticRequestParam {
 
@@ -25,18 +27,19 @@ public class StatisticRequestParam {
 
     private StatisticValue value;
 
+
     public StatisticRequestParam(String hashtag,
                                  StatisticType type,
                                  LocalDate start,
                                  LocalDate end,
                                  StatisticValue value) {
 
-        // TODO: hashtag = null일 경우 본인계정으로 설정
-        this.hashtag = hashtag == null ? "본인계정" : hashtag;
+        this.hashtag = hashtag;
         this.type = type == null ? StatisticType.DATE : type;
         this.start = start == null ? LocalDate.now().minusDays(7) : start;
         this.end = end == null ? LocalDate.now() : end;
         this.value = value == null ? StatisticValue.COUNT : value;
     }
+
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- (기능에서 어떤 부분이 구현되었는지 설명해주세요)
- (ex. `로그인 시, 구글 소셜 로그인 기능을 추가했습니다.`
- 통계 해시태그 parameter 가 null 일 경우, jwt 인증을 통해 유저 계정 정보 받아오도록 기능을 추가했습니다.
- 통계 스웨거 독스를 작성했습니다.

## 🌱 반영 브랜치

- (반영 브랜치를 표시합니다. ex. `feat/login -> dev` ) 
- (이슈를 완료했다면 닫을 이슈의 번호를 표기합니다. ex. `close #1` )
- feat/#ALL-21-statistics-jwt -> dev
- close #68

<br/>

## 🔥 트러블 슈팅 (선택)

<br/>

<br/>
