### PR TITLE
[Feat] 게시글 삭제 기능 개발

### DIFF
--- a/src/main/java/com/allclear/socialhub/common/exception/ErrorCode.java
+++ b/src/main/java/com/allclear/socialhub/common/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
 
     // POST
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시물입니다."),
-    POST_NOT_OWNER(HttpStatus.BAD_REQUEST, "본인 글만 수정/삭제가 가능합니다."),
+    POST_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "본인 글만 수정/삭제가 가능합니다."),
     POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물 타입입니다."),
     INVALID_HASHTAG_PATTERN(HttpStatus.BAD_REQUEST, "'#해시태그' 형식만 등록 가능합니다."),
 

--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagService.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagService.java
@@ -12,6 +12,8 @@ public interface HashtagService {
 
     List<Hashtag> updateHashtag(Long postId, List<String> hashtagList);
 
+    void deleteByPostId(Long postId);
+
     List<String> removeHashSymbol(List<String> hashtagList);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/common/hashtag/service/HashtagServiceImpl.java
@@ -31,8 +31,8 @@ public class HashtagServiceImpl implements HashtagService {
      * 해시태그 등록
      * 작성자 : 오예령
      *
-     * @param hashtagList
-     * @return
+     * @param hashtagList 등록 요청하는 hashtagList
+     * @return Hashtag 엔티티 List 반환
      */
     @Override
     @Transactional
@@ -60,9 +60,9 @@ public class HashtagServiceImpl implements HashtagService {
      * 해시태그 수정
      * 작성자 : 오예령
      *
-     * @param postId
-     * @param hashtagList
-     * @return
+     * @param postId      게시물Id
+     * @param hashtagList 수정 요청하는 hashtagList
+     * @return createHashtag()를 호출
      */
     @Override
     @Transactional
@@ -99,7 +99,32 @@ public class HashtagServiceImpl implements HashtagService {
 
         // 새로 추가해야 하는 해시태그 반환
         return createHashtag(compareHashtagList);
+
     }
+
+    /**
+     * 해당 게시물이 가진 해시태그 연관관계 삭제
+     * 작성자 : 오예령
+     *
+     * @param postId 게시물
+     */
+    @Transactional
+    public void deleteByPostId(Long postId) {
+
+        JPADeleteClause deleteClause = new JPADeleteClause(entityManager, postHashtag);
+
+        deleteClause.where(
+                postHashtag.post.id.eq(postId)).execute();
+
+    }
+
+    /**
+     * 해당 게시물과 hashtagId 값들의 연관관계 삭제
+     * 작성자 : 오예령
+     *
+     * @param postId     게시물Id
+     * @param hashtagIds 삭제가 필요한 hashtagId List
+     */
 
     @Transactional
     public void deleteByPostIdAndHashtagIds(Long postId, List<Long> hashtagIds) {
@@ -110,13 +135,14 @@ public class HashtagServiceImpl implements HashtagService {
                 postHashtag.post.id.eq(postId)
                         .and(postHashtag.hashtag.id.in(hashtagIds))
         ).execute();
+
     }
 
     /**
      * 해시태그 검증 및 '#' 삭제
      * 작성자 : 오예령
      *
-     * @param hashtagList
+     * @param hashtagList '#'가 포함된 hashtagList
      * @return '#'가 삭제된 hashtagList 반환
      */
     public List<String> removeHashSymbol(List<String> hashtagList) {

--- a/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/like/repository/PostLikeRepository.java
@@ -23,4 +23,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
             @Param("end") LocalDate end,
             @Param("dateFormatPattern") String dateFormatPattern);
 
+    void deleteAllByPostId(Long postId);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/share/repository/PostShareRepository.java
@@ -23,4 +23,6 @@ public interface PostShareRepository extends JpaRepository<PostShare, Long> {
             @Param("end") LocalDate end,
             @Param("dateFormatPattern") String dateFormatPattern);
 
+    void deleteAllByPostId(Long postId);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
+++ b/src/main/java/com/allclear/socialhub/post/common/view/repository/PostViewRepository.java
@@ -23,4 +23,6 @@ public interface PostViewRepository extends JpaRepository<PostView, Long> {
             @Param("end") LocalDate end,
             @Param("dateFormatPattern") String dateFormatPattern);
 
+    void deleteAllByPostId(Long postId);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -46,7 +46,17 @@ public class PostController {
     public ResponseEntity<PostResponse> updatePost(@Valid @RequestBody PostUpdateRequest updateRequest,
                                                    @PathVariable Long postId) {
 
+        // TODO : 추후 유저 토큰 검증 로직으로 수정
         return ResponseEntity.status(200).body(postService.updatePost(1L, postId, updateRequest));
+    }
+
+    @Operation(summary = "게시글 삭제", description = "게시물을 삭제합니다.")
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+
+        // TODO : 추후 유저 토큰 검증 로직으로 수정
+        postService.deletePost(1L, postId);
+        return ResponseEntity.status(200).body("성공적으로 삭제되었습니다.");
     }
 
     @Operation(summary = "게시물 좋아요", description = "게시물 좋아요를 추가합니다.")

--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
 
     @Operation(summary = "게시물 수정", description = "게시물을 수정합니다.")
     @PutMapping("/{postId}")
-    public ResponseEntity<PostResponse> updatePost(@RequestBody PostUpdateRequest updateRequest,
+    public ResponseEntity<PostResponse> updatePost(@Valid @RequestBody PostUpdateRequest updateRequest,
                                                    @PathVariable Long postId) {
 
         return ResponseEntity.status(200).body(postService.updatePost(1L, postId, updateRequest));

--- a/src/main/java/com/allclear/socialhub/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostCreateRequest.java
@@ -17,6 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 public class PostCreateRequest {
 
+    @NotNull(message = "게시물 타입을 확인해주세요.")
     private PostType type;
     @NotNull(message = "제목은 필수 입력 값입니다.")
     private String title;

--- a/src/main/java/com/allclear/socialhub/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostUpdateRequest.java
@@ -1,14 +1,19 @@
 package com.allclear.socialhub.post.dto;
 
 import com.allclear.socialhub.post.domain.Post;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@Builder
 public class PostUpdateRequest {
 
+    @NotNull(message = "제목은 필수 입력 값입니다.")
     private String title;
+    @NotNull(message = "내용은 필수 입력 값입니다.")
     private String content;
     private List<String> hashtagList;
 

--- a/src/main/java/com/allclear/socialhub/post/service/PostService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostService.java
@@ -22,4 +22,6 @@ public interface PostService {
 
     PostShareResponse sharePost(Long postId, Long userId);
 
+    void deletePost(Long userId, Long postId);
+
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -32,8 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.allclear.socialhub.common.exception.ErrorCode.POST_NOT_FOUND;
-import static com.allclear.socialhub.common.exception.ErrorCode.USER_NOT_EXIST;
+import static com.allclear.socialhub.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -91,6 +90,7 @@ public class PostServiceImpl implements PostService {
 
         // 1. 게시물 검증
         Post post = postCheck(postId);
+        if (!post.getUser().getId().equals(userId)) throw new CustomException(POST_OWNER_MISMATCH);
 
         Post updatePost = updateRequest.toEntity();
         post.update(updatePost);


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 게시글 삭제 기능 구현하였습니다.
- 게시글 삭제 시 좋아요와 공유, 조회수, 해시태그의 연관관계 데이터도 삭제하였습니다.
- 본인 글만 삭제 가능하도록 구현하였습니다.
- Controller단 유저 토큰 검증 추후 개발 예정입니다.

<br/>

## 🌱 반영 브랜치

- feat/#ALL-24-post-delete -> dev
- close #58 
<br/>