### PR TITLE
[Feat] 게시물 검색 기능 개발

### DIFF
--- a/src/main/java/com/allclear/socialhub/common/exception/ErrorCode.java
+++ b/src/main/java/com/allclear/socialhub/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     POST_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "본인 글만 수정/삭제가 가능합니다."),
     POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물 타입입니다."),
     INVALID_HASHTAG_PATTERN(HttpStatus.BAD_REQUEST, "'#해시태그' 형식만 등록 가능합니다."),
+    INVALID_SEARCH_CONDITION(HttpStatus.BAD_REQUEST, "알맞은 검색조건이 아닙니다."),
 
     // STATISTICS
     STATISTICS_INVALID_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 type parameter 입니다. expected: ['date', 'hour']"),

--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -84,7 +84,7 @@ public class PostController {
 
     @Operation(summary = "게시물 공유", description = "게시물 공유를 추가합니다.")
     @PostMapping("/share/{postId}")
-    public ResponseEntity<PostShareResponse> sharePost(@PathVariable Long postId, @RequestParam Long userId) {
+    public ResponseEntity<PostShareResponse> sharePost(@PathVariable("postId") Long postId, @RequestParam Long userId) {
 
         // TODO: 추후 유저 검증
         return ResponseEntity.status(201).body(postService.sharePost(postId, userId));

--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.allclear.socialhub.post.controller;
 
 import com.allclear.socialhub.post.common.like.dto.PostLikeResponse;
 import com.allclear.socialhub.post.common.share.dto.PostShareResponse;
+import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostPaging;
 import com.allclear.socialhub.post.dto.PostResponse;
@@ -32,15 +33,6 @@ public class PostController {
         return ResponseEntity.status(201).body(postService.createPost(1L, requestDto));
     }
 
-    @Operation(summary = "게시물 목록 조회", description = "게시물 목록을 조회합니다.")
-    @GetMapping
-    public ResponseEntity<PostPaging> getPosts(@PageableDefault Pageable pageable) {
-
-        // TODO : 추후 유저 검증 필요
-        return ResponseEntity.status(200).body(postService.getPosts(pageable));
-
-    }
-
     @Operation(summary = "게시물 수정", description = "게시물을 수정합니다.")
     @PutMapping("/{postId}")
     public ResponseEntity<PostResponse> updatePost(@Valid @RequestBody PostUpdateRequest updateRequest,
@@ -57,6 +49,30 @@ public class PostController {
         // TODO : 추후 유저 토큰 검증 로직으로 수정
         postService.deletePost(1L, postId);
         return ResponseEntity.status(200).body("성공적으로 삭제되었습니다.");
+    }
+
+    @Operation(summary = "게시물 검색 목록 조회", description = "게시물 검색 목록을 조회합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<PostPaging> searchPosts(
+            @PageableDefault Pageable pageable,
+            @RequestParam(value = "hashtag", required = false) String hashtag,
+            @RequestParam(value = "type", required = false) PostType type,
+            @RequestParam(value = "query", required = false, defaultValue = "") String query,
+            @RequestParam(value = "orderBy", required = false, defaultValue = "created_at") String orderBy,
+            @RequestParam(value = "sort", required = false, defaultValue = "desc") String sort,
+            @RequestParam(value = "searchBy", required = false, defaultValue = "title") String searchBy) {
+
+        return ResponseEntity.status(200)
+                .body(postService.searchPosts(pageable, "username", hashtag, type, query, orderBy, sort, searchBy));
+    }
+
+    @Operation(summary = "게시물 목록 조회", description = "게시물 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<PostPaging> getPosts(@PageableDefault Pageable pageable) {
+
+        // TODO : 추후 유저 검증 필요
+        return ResponseEntity.status(200).body(postService.getPosts(pageable));
+
     }
 
     @Operation(summary = "게시물 좋아요", description = "게시물 좋아요를 추가합니다.")

--- a/src/main/java/com/allclear/socialhub/post/domain/SearchByType.java
+++ b/src/main/java/com/allclear/socialhub/post/domain/SearchByType.java
@@ -1,0 +1,32 @@
+package com.allclear.socialhub.post.domain;
+
+import com.allclear.socialhub.common.exception.CustomException;
+import com.allclear.socialhub.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.EnumSet;
+
+@Getter
+@AllArgsConstructor
+public enum SearchByType {
+    TITLE("title"),
+    CONTENT("content");
+
+    private final String searchBy;
+
+    public static EnumSet<SearchByType> fromString(String searchBy) {
+
+        EnumSet<SearchByType> result = EnumSet.noneOf(SearchByType.class);
+        if (searchBy != null && !searchBy.isEmpty()) {
+            for (String value : searchBy.split(",")) {
+                try {
+                    result.add(SearchByType.valueOf(value.trim().toUpperCase()));
+                } catch (IllegalArgumentException e) {
+                    throw new CustomException(ErrorCode.INVALID_SEARCH_CONDITION);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
@@ -2,16 +2,14 @@ package com.allclear.socialhub.post.dto;
 
 import com.allclear.socialhub.post.domain.PostType;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostListResponse {
@@ -27,7 +25,7 @@ public class PostListResponse {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
-    
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryImpl.java
@@ -2,18 +2,30 @@ package com.allclear.socialhub.post.repository.querydsl;
 
 import com.allclear.socialhub.post.common.hashtag.domain.QHashtag;
 import com.allclear.socialhub.post.common.hashtag.domain.QPostHashtag;
+import com.allclear.socialhub.post.domain.Post;
+import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.domain.QPost;
+import com.allclear.socialhub.post.domain.SearchByType;
 import com.allclear.socialhub.post.dto.PostListResponse;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.allclear.socialhub.post.common.hashtag.domain.QHashtag.hashtag;
+import static com.allclear.socialhub.post.common.hashtag.domain.QPostHashtag.postHashtag;
+import static com.allclear.socialhub.post.domain.QPost.post;
+
+@Slf4j
 public class PostRepositoryImpl implements PostRepositoryQuerydsl {
 
     private final JPAQueryFactory queryFactory;
@@ -72,5 +84,124 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
 
         return new PageImpl<>(postList, pageable, total);
     }
+
+    public Page<PostListResponse> searchPosts(Pageable pageable, String username, String hashtagQuery, PostType type, String query, String orderBy, String sort, String searchBy) {
+
+        // 기본 쿼리 설정을 위한 메소드 호출
+        JPAQuery<Post> queryBase = buildBaseQuery(username, hashtagQuery, type, query, searchBy);
+
+        // 정렬 조건 설정
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(orderBy, sort);
+        queryBase.orderBy(orderSpecifier);
+
+        // 페이징 및 데이터 조회
+        List<Post> posts = queryBase
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // Post 엔티티를 PostListResponse로 변환
+        List<PostListResponse> postList = posts.stream()
+                .map(this::mapToPostListResponse)
+                .collect(Collectors.toList());
+
+        // 총 게시물 수 조회
+        long total = queryBase.fetchCount();
+
+        // 결과를 Page 형태로 반환
+        return new PageImpl<>(postList, pageable, total);
+    }
+
+    // 기본 쿼리 설정 메소드 (해당 게시물에서 조건 필터링 진행)
+    private JPAQuery<Post> buildBaseQuery(String username, String hashtagQuery, PostType type, String query, String searchBy) {
+
+        JPAQuery<Post> queryBase = queryFactory
+                .selectFrom(post)
+                .leftJoin(postHashtag).on(postHashtag.post.id.eq(post.id))
+                .leftJoin(hashtag).on(hashtag.id.eq(postHashtag.hashtag.id))
+                .distinct();
+
+        // 해시태그 필터 적용
+        if (hashtagQuery != null && !hashtagQuery.isEmpty()) {
+            queryBase.where(hashtag.content.eq(hashtagQuery));
+        } else if (username != null && !username.isEmpty()) {
+            // 해시태그가 없으면 username으로 검색
+            queryBase.where(post.user.username.eq(username));
+        }
+
+        // 게시물 타입 필터 적용
+        if (type != null) {
+            queryBase.where(post.type.eq(type));
+        }
+
+        // 검색 필터 적용 (searchBy에 따라 title 또는 content에서 검색, 미입력 시 title과 content 모두에서 검색)
+        applySearchFilter(queryBase, query, searchBy);
+
+        return queryBase;
+    }
+
+    // 검색 필터 적용 메소드
+    private void applySearchFilter(JPAQuery<Post> queryBase, String query, String searchBy) {
+
+        log.info("searchBy : {}", searchBy);
+        EnumSet<SearchByType> searchByTypes = SearchByType.fromString(searchBy);
+
+        if (searchByTypes.isEmpty()) {
+            queryBase.where(post.title.containsIgnoreCase(query)
+                    .or(post.content.containsIgnoreCase(query)));
+        } else {
+            if (searchByTypes.contains(SearchByType.TITLE)) {
+                queryBase.where(post.title.containsIgnoreCase(query));
+            }
+
+            if (searchByTypes.contains(SearchByType.CONTENT)) {
+                queryBase.where(post.content.containsIgnoreCase(query));
+            }
+        }
+    }
+
+    // 정렬 조건 설정 메소드
+    private OrderSpecifier<?> getOrderSpecifier(String orderBy, String sort) {
+
+        switch (orderBy) {
+            case "created_at":
+                return "asc".equalsIgnoreCase(sort) ? post.createdAt.asc() : post.createdAt.desc();
+            case "updated_at":
+                return "asc".equalsIgnoreCase(sort) ? post.updatedAt.asc() : post.updatedAt.desc();
+            case "like_count":
+                return "asc".equalsIgnoreCase(sort) ? post.likeCnt.asc() : post.likeCnt.desc();
+            case "share_count":
+                return "asc".equalsIgnoreCase(sort) ? post.shareCnt.asc() : post.shareCnt.desc();
+            case "view_count":
+                return "asc".equalsIgnoreCase(sort) ? post.viewCnt.asc() : post.viewCnt.desc();
+            default:
+                return post.id.desc(); // 기본 정렬: Id 내림차순
+        }
+    }
+
+    // Post 엔티티를 PostListResponse로 변환하는 메소드
+    private PostListResponse mapToPostListResponse(Post postEntity) {
+
+        List<String> hashtags = queryFactory
+                .select(hashtag.content)
+                .from(postHashtag)
+                .join(hashtag).on(hashtag.id.eq(postHashtag.hashtag.id))
+                .where(postHashtag.post.id.eq(postEntity.getId()))
+                .fetch();
+
+        return PostListResponse.builder()
+                .postId(postEntity.getId())
+                .type(postEntity.getType())
+                .title(postEntity.getTitle())
+                .content(postEntity.getContent())
+                .viewCnt(postEntity.getViewCnt())
+                .likeCnt(postEntity.getLikeCnt())
+                .shareCnt(postEntity.getShareCnt())
+                .createdAt(postEntity.getCreatedAt())
+                .updatedAt(postEntity.getUpdatedAt())
+                .hashtagList(hashtags)
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryQuerydsl.java
+++ b/src/main/java/com/allclear/socialhub/post/repository/querydsl/PostRepositoryQuerydsl.java
@@ -1,5 +1,6 @@
 package com.allclear.socialhub.post.repository.querydsl;
 
+import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.dto.PostListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,5 +8,7 @@ import org.springframework.data.domain.Pageable;
 public interface PostRepositoryQuerydsl {
 
     Page<PostListResponse> getPosts(Pageable pageable);
+
+    Page<PostListResponse> searchPosts(Pageable pageable, String username, String hashtagQuery, PostType type, String query, String orderBy, String sort, String searchBy);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.allclear.socialhub.post.service;
 
 import com.allclear.socialhub.post.common.like.dto.PostLikeResponse;
 import com.allclear.socialhub.post.common.share.dto.PostShareResponse;
+import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostPaging;
 import com.allclear.socialhub.post.dto.PostResponse;
@@ -16,12 +17,14 @@ public interface PostService {
 
     PostResponse updatePost(Long userId, Long postId, PostUpdateRequest updateRequest);
 
+    void deletePost(Long userId, Long postId);
+
+    PostPaging searchPosts(Pageable pageable, String username, String hashtag, PostType type, String query, String orderBy, String sort, String searchBy);
+
     PostPaging getPosts(Pageable pageable);
 
     PostLikeResponse likePost(Long postId, Long userId);
 
     PostShareResponse sharePost(Long postId, Long userId);
-
-    void deletePost(Long userId, Long postId);
 
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -146,11 +146,18 @@ public class PostServiceImpl implements PostService {
     }
 
     /**
-     * 4. 게시물 검색 조회
+     * 4. 게시물 검색 목록 조회
      * 작성자 : 오예령
      *
      * @param pageable Pagination 요청 정보 관련 인터페이스
-     * @return 페이징 처리가 된 게시물 검색 결과 목록
+     * @param username 유저 계정이름
+     * @param hashtag  검색할 hashtag
+     * @param type     게시물 타입 ("INSTAGRAM", "FACEBOOK", "TWITTER", "THREADS" 만 가능)
+     * @param query    검색할 query
+     * @param orderBy  정렬기준
+     * @param sort     순서
+     * @param searchBy 검색 범위 ("TITLE", "CONTENT", "TITLE, CONTENT"만 가능)
+     * @return 페이징 처리가 된 검색 결과에 맞는 목록 반환
      */
     @Override
     public PostPaging searchPosts(Pageable pageable, String username, String hashtag, PostType type, String query, String orderBy, String sort, String searchBy) {

--- a/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostServiceImpl.java
@@ -13,6 +13,7 @@ import com.allclear.socialhub.post.common.share.dto.PostShareResponse;
 import com.allclear.socialhub.post.common.share.repository.PostShareRepository;
 import com.allclear.socialhub.post.common.view.repository.PostViewRepository;
 import com.allclear.socialhub.post.domain.Post;
+import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.dto.PostCreateRequest;
 import com.allclear.socialhub.post.dto.PostPaging;
 import com.allclear.socialhub.post.dto.PostResponse;
@@ -142,6 +143,19 @@ public class PostServiceImpl implements PostService {
         // 게시물 삭제
         postRepository.delete(post);
 
+    }
+
+    /**
+     * 4. 게시물 검색 조회
+     * 작성자 : 오예령
+     *
+     * @param pageable Pagination 요청 정보 관련 인터페이스
+     * @return 페이징 처리가 된 게시물 검색 결과 목록
+     */
+    @Override
+    public PostPaging searchPosts(Pageable pageable, String username, String hashtag, PostType type, String query, String orderBy, String sort, String searchBy) {
+
+        return new PostPaging(postRepository.searchPosts(pageable, username, hashtag, type, query, orderBy, sort, searchBy));
     }
 
     /**


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 게시물 검색 목록 조회 API 작성하였습니다.
- querydsl을 활용해 기능 구현하였습니다.
- Springboot에서 지원하는 @PageableDefault를 활용해 한 번에 조회하고자 하는 게시물의 수는 size, 조회하고자 하는 페이지는 page 값으로 사용하였습니다.
    <img width="649" alt="image" src="https://github.com/user-attachments/assets/3b195afd-cce6-4b99-8ced-35b8e60285f3">
    
   <img width="1237" alt="image" src="https://github.com/user-attachments/assets/cea08dc0-ab4d-4a25-b963-055ff5ca9936">

- 게시물 검색 조건인 searchBy 항목은 title과 content로만 검색이 가능하여 enum으로 관리하였습니다.
- 해시태그 검색의 경우 입력값과 정확히 일치하는 경우에만 조건을 만족하는 요구사항을 반영하여 작성하였습니다.
- 검색 조건 관련 오류가 발생하는 경우에 반환할 에러코드 추가하였습니다.

## 🌱 반영 브랜치

- feat/#ALL-25-post-search -> dev
- close #94 

<br/>

## 🔥 트러블 슈팅 (선택)
### 많은 검색 조건 요구사항
- 조건을 고려하여 결과값을 생성하는 과정에서 메소드가 길어지고 가독성이 좋지 않았습니다.
- 객체지향적인 코드 작성을 고려, 메소드별로 하나의 기능을 구현하도록 분리하여 리팩토링하였습니다.
### Parameter 관련 고민
- Parameter로 받는 데이터의 양이 많아 고민하였습니다. 
- 찾아보니 Parameter로 받아오게 되면 메모리를 차지하는 부분은 적지만 유지보수에는 어려움이 있다는 결과를 확인했습니다. 
- 추후에는 dto로 수정해야겠다는 생각을 했습니다.

> ### 메모리 사용 비교
> 
> 긴 파라미터: 메모리 사용량은 적지만, 메소드가 복잡해질 수 있고 유지보수 및 가독성이 떨어질 수 있습니다. 메모리 측면에서 큰 차이는 없지만, 복잡한 메소드 서명은 관리가 어려울 수 있습니다.
> 
> DTO 사용: 객체를 생성하므로 메모리 사용량이 증가할 수 있지만, 코드의 구조가 더 명확해지고 유지보수가 쉬워집니다. 현대의 메모리 관리 시스템에서는 작은 메모리 오버헤드는 대부분 무시할 수 있으며, DTO를 사용함으로써 얻는 코드 품질과 유지보수 용이성의 이점이 더 큽니다.
> 
> 결론적으로, DTO를 사용하는 것이 코드의 유지보수성, 가독성, 확장성 측면에서 더 많은 이점을 제공합니다. 메모리 사용량이 증가할 수 있지만, 현대의 메모리 관리에서는 작은 오버헤드는 대부분 문제되지 않습니다. 따라서, 일반적으로 DTO를 사용하는 것이 바람직합니다.