### PR TITLE
[Refactor] 게시물 목록 content 글자수 제한 추가

### DIFF
--- a/src/main/java/com/allclear/socialhub/post/controller/PostController.java
+++ b/src/main/java/com/allclear/socialhub/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.allclear.socialhub.post.controller;
 
 import com.allclear.socialhub.post.common.like.dto.PostLikeResponse;
 import com.allclear.socialhub.post.common.share.dto.PostShareResponse;
+import com.allclear.socialhub.post.domain.PostType;
 import com.allclear.socialhub.post.dto.*;
 import com.allclear.socialhub.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
+++ b/src/main/java/com/allclear/socialhub/post/dto/PostListResponse.java
@@ -29,4 +29,13 @@ public class PostListResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 
+    public void setContent(String content) {
+
+        if (content != null && content.length() > 20) {
+            this.content = content.substring(0, 20); // 글자수 제한 적용
+        } else {
+            this.content = content;
+        }
+    }
+
 }

--- a/src/main/java/com/allclear/socialhub/post/service/PostService.java
+++ b/src/main/java/com/allclear/socialhub/post/service/PostService.java
@@ -2,8 +2,8 @@ package com.allclear.socialhub.post.service;
 
 import com.allclear.socialhub.post.common.like.dto.PostLikeResponse;
 import com.allclear.socialhub.post.common.share.dto.PostShareResponse;
-import com.allclear.socialhub.post.dto.*;
 import com.allclear.socialhub.post.domain.PostType;
+import com.allclear.socialhub.post.dto.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -25,7 +25,5 @@ public interface PostService {
     PostShareResponse sharePost(Long postId, Long userId);
 
     PostDetailResponse getPostDetail(Long postId, Long userId);
-
-    void deletePost(Long userId, Long postId);
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 게시물 목록 조회 시 content 글자수를 20자로 제한하는 코드를 추가하였습니다.
- PostService의 중복된 메서드 제거 및 PostController의 누락된 import를 추가하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/#ALL-88-post-list-text-length -> dev
- close #107 